### PR TITLE
Fix method redefine warning

### DIFF
--- a/kingfisher/router.rb
+++ b/kingfisher/router.rb
@@ -10,14 +10,13 @@ module Kingfisher
     end
 
     private
-    attr_reader :route_set
+
+    def route_set
+      @_route_set ||= RouteSet.new
+    end
 
     def route(request)
       route_set.match(request)
-    end
-
-    def route_set
-      @route_set ||= RouteSet.new
     end
 
     def get(url, controller, action)


### PR DESCRIPTION
Remove the attr_reader (fixes warning) and reorder.

```
kingfisher-example/kingfisher/router.rb:19: warning: method redefined;
discarding old route_set
```
